### PR TITLE
Make the sorter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The basic usage of the lib requires 2 parameters: an array of the RTCConfigs tha
   }
 
   echo(rtcConfigs, options)
-    .then((res) => console.log(res))
+    .then(console.log)
     .catch(console.error)
 ```
 
@@ -66,7 +66,7 @@ The output to this call should be similar to this:
 
 After that it's up to you on how to use it.\
 The easy route is to use the first configuration from the `sorted` key, entries are already sorted from faster to slower by `avgRTT`, since latency is one major factor affecting a WebRTC connection's quality.
-If you want to, you could pick any of the sorted items accordingly to your own criteria. For example, consider using the historically more stable configuration even when the latency is slightly worse.
+If you want to, you could change the way the items are sorted accordingly to your own criteria. For example, consider using the historically more stable configuration even when the latency is slightly worse.
 
 ### Options
 
@@ -77,6 +77,7 @@ If you want to, you could pick any of the sorted items accordingly to your own c
 | iceTimeout | `number` | no | `1000` ms | This is the total time that the peer will have to connect. This goes from the Peer creation to the ice gathering and ice connection. |
 | dataTimeout | `number` | no | `100` ms | This represents the timeout for each of the requests made by the data channel. When it times out the defined value is added to the average calculation. |
 | requests | `number` | no | 10 | This is the amount of times data will be send using the data channel before calculating the average. |
+| sorter | `function` | no | (a, b) => a.avgRTT - b.avgRTT | This function is used to sort the best configuration using the ping data. In addition to the `avgRTT`, the props also have the `iceGatheringTime`, `iceConnectionTime`, and the `rtcConfig` which is the original configuration used to start the test. |
 
 ## Contributing
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 /* istanbul ignore file */
 
 export * from './echo';
+export * from './types';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,6 +24,8 @@ export type EchoConfig = {
   iceTimeout?: number;
   dataTimeout?: number;
   requests?: number;
+  // eslint-disable-next-line no-unused-vars
+  sorter?: (a: PeerWithStats, b: PeerWithStats) => number;
 };
 
 export type EchoResponse = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subspacecom/echo-test",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A JS lib to be used with Subspace's WebRTC echo server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Make it possible to pass the sorted function when starting the test.
This is necessary to be able to give some advantages to historically more stable connections.

Once this PR is merged it will be possible to pass the sorted function on the test config as such:
```typescript
  import { echo } from '@subspacecom/echo-test';

  const rtcConfigs = [
    { iceServers: [{ urls: ['stun:stun.l.google.com:193028'] }] },
    { iceServers: [{ urls: ['stun:global.stun.twilio.com:3478'] }] },
  ]

  const options = {
    signalUrl: 'https://echo-server-url.here/offer',
    sorter: (a, b) => (a.avgRTT + a.iceConnectionTime) - (b.avgRTT + b.iceConnectionTime)
  }

  echo(rtcConfigs, options)
    .then(console.log)
    .catch(console.error)
```