### PR TITLE
Fix CI cache error

### DIFF
--- a/.github/workflows/ci.js.yml
+++ b/.github/workflows/ci.js.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
     - uses: borales/actions-yarn@v2.3.0
       with:
         cmd: install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subspacecom/echo-test",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A JS lib to be used with Subspace's WebRTC echo server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm disabling the node cache as it was failing.
I'm also bumping the version to 0.1.5 which is the latest published one